### PR TITLE
TUSK_URLS are considered

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 **Chrome:** https://chrome.google.com/webstore/detail/fmhmiaejopepamlcjkncpgpdjichnecm
 
+## Tusk Custom Fields
+
+* `TUSK_URLS`: a comma separated list of URLs or hostnames to which the entry should always match.  For example, active directory login credentials that must match several sites.  e.g. `my.login.domain.com,https://github.com,foobar.net`
+
 ## Build Setup
 
 Tusk requires:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,26 @@ const urlencode = function(str) {
 	return encodeURIComponent(str).replace(/[!'()*]/g, escape);
 }
 
+const getValidTokens = tokenString => {
+	if (!tokenString)
+		return []
+	else
+		return tokenString.toLowerCase().split(/\.|\s|\//).filter(t => {
+			return (t && t !== "com" && t !== "www" && t.length > 1)
+		})
+} // end getValidTokens
+
+const parseUrl = url => {
+	if (url && !url.indexOf('http') == 0)
+		url = 'http://' + url
+	//from https://gist.github.com/jlong/2428561
+	var parser = document.createElement('a')
+	parser.href = url
+	return parser
+} // end parseUrl
+
 export {
+	getValidTokens,
+	parseUrl,
 	urlencode
 }

--- a/services/googleDrivePasswordFileManager.js
+++ b/services/googleDrivePasswordFileManager.js
@@ -172,9 +172,15 @@ function GoogleDrivePasswordFileManager(settings) {
 	}
 
 	// If this browser has the getAuthToken function.  Hack for #64
-	if (chrome.identity.getAuthToken !== undefined){
-		oauth['auth'] = chrome_auth;
+	try {
+		if (chrome.identity.getAuthToken !== undefined){
+			oauth['auth'] = chrome_auth;
+		}
+	} 
+	catch (e) {
+		console.info("Firefox mobile detected.")
 	}
+
 
 	return OauthManager(settings, oauth)
 }


### PR DESCRIPTION
Adds support for a custom field, "TUSK_URLS", which is a comma separated list of URLs.

e.g. TUSK_URLS=`http://github.com,amazon.com,company.login.net` would make the entry be a 100% match for those domains.

Solves #85 