### PR TITLE
Remove tests from README, since they seem to not exist anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,9 @@ yarn build
 # run the packer script targeted for 'chrome' or 'firefox' after build
 yarn bundle
 
-# build the tests
-yarn build-tests
-
-# static reload with file watch for tests
-yarn watch-tests
 ```
 
 For detailed explanation on how things work, consult the [docs for vue-loader](http://vuejs.github.io/vue-loader).
-
-## Running tests
-
-To run tests, first build them with `yarn build-tests` or `yarn watch-tests` then open `tests/test.html` in a browser.s
 
 ## Browser Permissions
 


### PR DESCRIPTION
I tried really hard to find these tests but couldn't find any.

Isn't that a leftover from some kind of boilerplate?

Testing: not neccessary 