### PR TITLE
Add runtime.lastError checking to allOriginPermissions

### DIFF
--- a/src/components/AdvancedSettings.vue
+++ b/src/components/AdvancedSettings.vue
@@ -187,9 +187,17 @@
 			},
 			allOriginPermission(val) {
 				if (val) {
-					chrome.permissions.request(this.allOriginPerms);
+					chrome.permissions.request(this.allOriginPerms, () => {
+					    if (chrome.runtime.lastError) {
+					        console.warn(chrome.runtime.lastError.message)
+						}
+					})
 				} else {
-					chrome.permissions.remove(this.allOriginPerms)
+					chrome.permissions.remove(this.allOriginPerms, () => {
+                        if (chrome.runtime.lastError) {
+                            console.warn(chrome.runtime.lastError.message)
+                        }
+					})
 				}
 			},
 			strictMatchEnabled(newval, oldval) {


### PR DESCRIPTION
I couldn't reproduce. `macOS 10.13.6` with `Chrome 70.0.3513.0 (Official Build) canary`

But I read up on this errors and this should fix it.

@subdavis 