### PR TITLE
Unlock.vue: shrink password input to avoid overlap

### DIFF
--- a/src/components/Unlock.vue
+++ b/src/components/Unlock.vue
@@ -447,6 +447,7 @@ export default {
     float: left;
   }
   .masterPasswordInput {
+    border-top: 1px solid $light-gray;
     position: relative;
     i {
       position: absolute;
@@ -458,12 +459,11 @@ export default {
   }
   input[type="text"],
   input[type="password"] {
-    width: 100%;
+    width: calc(100% - 1em);
     box-sizing: border-box;
     font-size: 18px;
     border-width: 0px 0px;
     padding: 5px $wall-padding;
-    border-top: 1px solid $light-gray;
     &:focus {
       outline: none;
     }


### PR DESCRIPTION
The mask/unmask icon overlaps with the input if it is not shrunk at
least a bit.

The border is moved to the parent `div` so that the border continues to
show for the entire width rather than the narrower input field width.

Fixes #284