### PR TITLE
Add support for KeepassXC-style TOTP fields

### DIFF
--- a/src/components/EntryDetails.vue
+++ b/src/components/EntryDetails.vue
@@ -102,6 +102,16 @@ export default {
 					'protected': true,
 					'protectedAttr': this.entry.protectedData[protectedKey]
 				})
+				// some keepass programs (e.g. keepassxc) store TOTP params in
+				// "TOTP Seed" & "TOTP Settings" (tOTPSeed & tOTPSettings) instead of the otp URL
+				// in this case, we also want to display the computed TOTP value
+				if (protectedKey === "tOTPSeed" && "tOTPSettings" in this.entry) {
+					let otpSettings = this.entry["tOTPSettings"].split(';')
+					let otpSeed = this.unlockedState.getDecryptedAttribute(this.entry, protectedKey)
+					if (otpSettings.length >= 2) {
+						this.setupOTP(OTP.makeUrl(otpSeed , otpSettings[0], otpSettings[1]))
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Some keepass programs (including Tusk) support the TOTP key URI format described in https://github.com/google/google-authenticator/wiki/Key-Uri-Format but others (like KeepassXC) store their TOTP parameters in a different format. They store the seed in an attribute called "TOTP Seed" and the other parameters like the number of digits and the time interval in an attribute called "TOTP Settings".  This PR adds support for these fields.