### PR TITLE
SharedLinkProvider cleanup

### DIFF
--- a/services/sharedUrlFileManager.js
+++ b/services/sharedUrlFileManager.js
@@ -17,8 +17,9 @@ function SharedUrlFileManager() {
 		title: 'Shared Link',
 		icon: 'icon-link',
 		chooseTitle: 'Shared Link',
-		chooseDescription: 'Rather than granting full access to your cloud storage provider, get a shared link and paste it in.  Any direct HTTP link will do, and Dropbox and OwnCloud are supported.',
-		setUrls: setUrls,
+		chooseDescription: 'Rather than granting full access to your cloud storage provider, get a shared link and paste it in.  Any direct HTTP link will do, and Dropbox and Google Drive are supported.',
+		addUrl: addUrl,
+		removeUrl: removeUrl,
 		getUrls: getUrls,
 		login: enable,
 		logout: disable,
@@ -76,20 +77,43 @@ function SharedUrlFileManager() {
 		});
 	}
 
-	function setUrls(urls) {
-		if (urls)
+	function addUrl(url) {
+		return this.getUrls().then(urls => {
+			let index = urls.findIndex(oldUrl => url.title === oldUrl.title);
+			if (index !== -1) {
+				urls[index] = url;
+			} else {
+				urls.push(url);
+			}
+
 			return chromePromise.storage.local.set({
 				'sharedUrlList': urls
 			});
-		else
-			return chromePromise.storage.local.remove('sharedUrlList');
+		});
+	}
+
+	function removeUrl(url) {
+		return this.getUrls().then(urls => {
+			let index = urls.findIndex(oldUrl => url.title === oldUrl.title);
+			if (index !== -1) {
+				urls.splice(index, 1);
+			}
+
+			if (urls) {
+				return chromePromise.storage.local.set({
+					'sharedUrlList': urls
+				});
+			} else {
+				return chromePromise.storage.local.remove('sharedUrlList');
+			}
+		});
 	}
 
 	function getUrls() {
 		return chromePromise.storage.local.get('sharedUrlList').then(results => {
 			if (results.hasOwnProperty('sharedUrlList'))
 				return results.sharedUrlList;
-			return false;
+			return [];
 		});
 	}
 


### PR DESCRIPTION
- Remove SharedUrl paste-in class, keep necessary bits
- Remove ownCloud-specific handler (can mangle non-ownCloud links too)
- Push objects to storage one at a time
- Do not attach objects to this before storing (avoids vue.js
contamination)

Fixes #307 