### PR TITLE
Detect Vivaldi with a user agent

### DIFF
--- a/services/googleDrivePasswordFileManager.js
+++ b/services/googleDrivePasswordFileManager.js
@@ -172,7 +172,7 @@ function GoogleDrivePasswordFileManager(settings) {
 	// If this browser has the getAuthToken function...  Hack for #64
 	// There is the getAuthToken function in Opera, but it isn't supported. Detect Opera by the chrome.search function.
 	try {
-		if (chrome.identity.getAuthToken !== undefined && chrome.search === undefined) {
+	    if (chrome.identity.getAuthToken !== undefined && chrome.search === undefined && !window.navigator.userAgent.match("Vivaldi")) {
 			oauth['auth'] = chrome_auth;
 		}
 	}


### PR DESCRIPTION
This pull request closes issue #130 .
Tusk calls `window.navigator.userAgent` to test that this browser is Vivaldi or not.
Since I don't know which APIs I should use to test like #300 , I choose `window.navigator.userAgent` .

Cheers 🍻 


